### PR TITLE
Bluetooth: align player id so auto-discover player becomes active (acr#11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audiocontrol"
-version = "0.7.12"
+version = "0.7.13"
 authors = ["HiFiBerry <support@hifiberry.com>"]
 edition = "2021"
 description = "AudioControl server"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+hifiberry-audiocontrol (0.7.13) stable; urgency=medium
+
+  * Bluetooth: fix the auto-discover player never becoming the active player.
+    The controller registered (and was looked up by ActiveMonitor) under the
+    prefixed id "bluetooth:auto-discover" returned by the get_player_id() trait
+    override, but StateChanged events were stamped via the inherent
+    BasePlayerController::notify_state_changed() with the bare base id
+    "auto-discover". The ids never matched, so ActiveMonitor logged "Could not
+    find player bluetooth:auto-discover to set active" and the Bluetooth player
+    stayed is_active=false while music was playing. Construct the base
+    controller with the already-prefixed id and delegate the trait override to
+    the base so event id and lookup id share a single source of truth.
+    (hifiberry/acr#11)
+
+ -- HiFiBerry <info@hifiberry.com>  Mon, 15 Jun 2026 13:30:00 +0000
+
 hifiberry-audiocontrol (0.7.12) stable; urgency=medium
 
   * Add supports_delete capability flag to library API response

--- a/src/players/bluetooth/bluetooth.rs
+++ b/src/players/bluetooth/bluetooth.rs
@@ -48,9 +48,6 @@ pub struct BluetoothPlayerController {
     
     /// Flag to stop polling thread
     stop_polling: Arc<std::sync::atomic::AtomicBool>,
-    
-    /// Whether this controller was created in auto-discover mode
-    is_auto_discover: bool,
 }
 
 // Manually implement Clone for BluetoothPlayerController
@@ -68,7 +65,6 @@ impl Clone for BluetoothPlayerController {
             stop_scanning: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             poll_thread: Arc::new(RwLock::new(None)),
             stop_polling: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            is_auto_discover: self.is_auto_discover,
         }
     }
 }
@@ -113,11 +109,19 @@ impl BluetoothPlayerController {
     
     /// Create a new BluetoothPlayerController with a specific device address
     pub fn new_with_address(device_address: Option<String>) -> Self {
+        // Construct the player id WITH the "bluetooth:" prefix so it is the single
+        // source of truth. The base controller stores this id and the inherent
+        // BasePlayerController::notify_state_changed() stamps it onto every
+        // StateChanged event (PlayerSource). ActiveMonitor looks players up by the
+        // same id, so event id and lookup id must be identical. Previously the base
+        // id was the bare "auto-discover" while get_player_id() returned the prefixed
+        // "bluetooth:auto-discover", so the lookup never matched the event and the
+        // Bluetooth player was never promoted to active (hifiberry/acr#11).
         let player_id = match &device_address {
-            Some(addr) => addr.clone(),
-            None => "auto-discover".to_string(),
+            Some(addr) => format!("bluetooth:{}", addr),
+            None => "bluetooth:auto-discover".to_string(),
         };
-        
+
         let base = BasePlayerController::with_player_info("bluetooth", &player_id);
         
         // Set initial capabilities
@@ -129,9 +133,7 @@ impl BluetoothPlayerController {
             PlayerCapability::Previous,
         ]);
         base.set_capabilities_set(capabilities, false);
-        
-        let is_auto_discover = device_address.is_none();
-        
+
         let controller = BluetoothPlayerController {
             base,
             connection: Arc::new(Mutex::new(None)),
@@ -144,7 +146,6 @@ impl BluetoothPlayerController {
             stop_scanning: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             poll_thread: Arc::new(RwLock::new(None)),
             stop_polling: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            is_auto_discover,
         };
         
         info!("Created BluetoothPlayerController with address: {:?}", device_address);
@@ -977,16 +978,12 @@ impl PlayerController for BluetoothPlayerController {
     }
     
     fn get_player_id(&self) -> String {
-        // If controller was created in auto-discover mode, always return "bluetooth:auto-discover"
-        // If controller was created with specific device, return "bluetooth:<device_address>"
-        
-        if self.is_auto_discover {
-            "bluetooth:auto-discover".to_string()
-        } else {
-            // For specific device controllers, return the configured address with bluetooth prefix
-            let device_address = self.device_address.read().clone().unwrap_or_else(|| "unknown".to_string());
-            format!("bluetooth:{}", device_address)
-        }
+        // Delegate to the base controller, which holds the already-prefixed id
+        // ("bluetooth:auto-discover" or "bluetooth:<device_address>") set in
+        // new_with_address(). This keeps a single source of truth so the id on
+        // StateChanged events (stamped via the inherent base method) matches the id
+        // ActiveMonitor looks up (hifiberry/acr#11).
+        self.base.get_player_id()
     }
     
     fn send_command(&self, command: PlayerCommand) -> bool {


### PR DESCRIPTION
## Problem (acr#11)

When a phone is connected over Bluetooth and plays audio, the Bluetooth player is correctly detected and its state goes to `Playing`, but it is **never promoted to the active player** — so `is_active` stays `false` and the WebUI/now-playing never switches to Bluetooth.

## Root cause

ID inconsistency between the event source and the lookup:

- The auto-discover controller was registered (and looked up by `ActiveMonitor`) under the **prefixed** id `bluetooth:auto-discover`, returned by the `get_player_id()` **trait override**.
- But `StateChanged` events were stamped via the **inherent** `BasePlayerController::notify_state_changed()`, which uses the **base** id — the bare `auto-discover` (no prefix), because the base was constructed with `with_player_info("bluetooth", "auto-discover")`.

So every event carried `player_id: "auto-discover"` while `ActiveMonitor` searched for `bluetooth:auto-discover`. The lookup never matched and logged:

```
ActiveMonitor: Could not find player bluetooth:auto-discover to set active
```

(The reporter's "ActiveMonitor filters by player type" hypothesis was ruled out — there is no type filter; it's purely the id mismatch.)

## Fix

Give the id a single source of truth: construct the base controller with the **already-prefixed** id and delegate the `get_player_id()` override to the base (matching how `mpris`/`lms` do it). Now the event id and the lookup id are identical. The now-unused `is_auto_discover` field is removed.

The externally visible id is unchanged (`bluetooth:auto-discover` / `bluetooth:<addr>`), so API consumers are unaffected. `tests.rs` (expects `bluetooth:80:B9:89:1E:B5:6F`) still passes.

## Verified on a live system (CM5, 0.7.13)

Built the package and installed it on a dev unit with a phone paired + playing A2DP:

```
players API:  {"name":"bluetooth","id":"bluetooth:auto-discover","state":"playing","is_active":true}
journal:      ActiveMonitor: Successfully set active player to bluetooth:bluetooth:auto-discover
```

The "Could not find player" warning is gone and the Bluetooth player becomes active on play.

Fixes #11