### PR TITLE
Refine: Remove cross-compile from build.sh, adjust control to allow for t64 dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,10 +2,6 @@
 
 cd `dirname $0`
 
-# Enable cross-compile support if configured
-_CC_ENV="$(dirname "$0")/../../../scripts/cross-compile-env.sh"
-if [ -f "$_CC_ENV" ]; then source "$_CC_ENV"; else echo "Not using cross-compilation (${_CC_ENV} does not exist)"; fi
-
 # Check if DIST is set by environment variable
 if [ -n "$DIST" ]; then
     echo "Using distribution from DIST environment variable: $DIST"

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/hifiberry/acr
 
 Package: hifiberry-audiocontrol
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libdbus-1-3, libasound2, python3
+Depends: ${shlibs:Depends}, ${misc:Depends}, libdbus-1-3, libasound2 | libasound2t64, python3
 Suggests: python3-websocket
 Breaks: hifiberry-librespot (<< 0.8.0.7),
         hifiberry-shairport (<< 1:5.2.1.2),


### PR DESCRIPTION
Removes cross-compile call from build.sh, which has been placed into the hifiberry-os build.sh script for acr.

Additionally, it adds trixie dependency satisfaction by using t64.